### PR TITLE
Versão 2.2.0 - Converter para Moment.js

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>br.com.eits.codegen</groupId>
     <artifactId>ts-codegen-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>2.1.3</version>
+    <version>2.2.0</version>
 
     <build>
         <plugins>

--- a/src/main/resources/templates/services-wrapper.ts
+++ b/src/main/resources/templates/services-wrapper.ts
@@ -5,7 +5,8 @@ import { Observable, Observer } from 'rxjs';
  * path é o caminho SEM BARRA AO FINAL para o broker. Por padrão é simplesmente 'broker'
  */
 export interface BrokerConfiguration {
-    path: string
+    path: string,
+    useMoment?: boolean
 }
 
 export let BROKER_CONFIGURATION = new InjectionToken<BrokerConfiguration>('broker.configuration');
@@ -40,19 +41,46 @@ export function dwrWrapper(configuration: BrokerConfiguration, serviceName: stri
 function loadDwrIfNeeded(configuration: BrokerConfiguration): Promise<void> {
     return new Promise<void>(resolve => {
         if ((window as any).dwr) {
-            resolve();
+            if ( configuration.useMoment ) {
+                shimDwrThenResolve( resolve );
+            } else {
+                resolve();
+            }
         } else {
             const path = `${configuration.path}/engine.js`;
             const tag: HTMLScriptElement = document.createElement('script');
             tag.src = path;
             tag.type = 'text/javascript';
-            tag.onload = () => resolve();
-            tag.onerror = () => resolve();
+            if ( configuration.useMoment ) {
+                tag.onload = () => shimDwrThenResolve( resolve );
+                tag.onerror = () => shimDwrThenResolve( resolve );
+            } else {
+                tag.onload = () => resolve();
+                tag.onerror = () => resolve();
+            }
             document.body.appendChild(tag);
         }
     });
 }
 
+/**
+ * Intercepta as chamadas de convert do dwr para converter o tipo Moment para Date caso ele esteja sendo utilizado
+ * @param resolve 
+ */
+function shimDwrThenResolve(resolve: Function) {
+    (function(dwr) {
+        const original = dwr.engine.serialize.convert;
+        dwr.engine.serialize.convert = function(batch, directrefmap, otherrefmap, data, name, depth) {
+            if (data != null && typeof data == 'object' && data._isAMomentObject) {
+                original(batch, directrefmap, otherrefmap, data.toDate(), name, depth);
+            } else {
+                original(batch, directrefmap, otherrefmap, data, name, depth);
+            }
+        };
+    })(window['dwr']);
+
+    resolve();
+}
 
 function loadServiceIfNeeded(configuration: BrokerConfiguration, name: string): Promise<any> {
     return new Promise<any>(resolve => {


### PR DESCRIPTION
Adicionado converter no dwr para Moment.
Com isso não é necessário converter objetos do Moment para Date antes de enviar para o backend.